### PR TITLE
QoL updates and improve usability of media controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,8 +30,3 @@ npm-debug.log*
 /plugins
 /www
 resources/android
-<<<<<<< HEAD
-./package-lock.json
-=======
-package-lock.json
->>>>>>> a618f0ac45351751d5937cb9e745a762fac0d4e0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@ Important Android stuff:
 
 - Replaced jcenter() with mavenCentral() since JCenter is deprecated.
 - Bumped cordovaAndroidVersion from 7.0.0 to 10.1.1.
+- Add more space between the media controls and make the play/pause button bigger.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,3 +60,8 @@ Important Android stuff:
 **Note about MPV versions: On older MPV versions the current chapter detection not working properly, if you experience issues with current chapter detection, please update your MPV version!**
 
 - [Feature request]: Current playing chapter in bold and has other color.
+
+## [next]
+
+- Replaced jcenter() with mavenCentral() since JCenter is deprecated.
+- Bumped cordovaAndroidVersion from 7.0.0 to 10.1.1.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:7.2.1'
@@ -20,7 +20,7 @@ apply from: "variables.gradle"
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/variables.gradle
+++ b/android/variables.gradle
@@ -10,5 +10,5 @@ ext {
     junitVersion = '4.13.1'
     androidxJunitVersion = '1.1.2'
     androidxEspressoCoreVersion = '3.3.0'
-    cordovaAndroidVersion = '7.0.0'
+    cordovaAndroidVersion = '10.1.1'
 }

--- a/src/components/playerController.vue
+++ b/src/components/playerController.vue
@@ -20,14 +20,6 @@
     </ion-row>
     <ion-row class="videoControls">
       <ion-col size="12">
-        <ion-button @click="onPlayPauseClicked" fill="clear">
-          <ion-icon
-            v-if="playerData.pause"
-            slot="icon-only"
-            :icon="playOutline"
-          ></ion-icon>
-          <ion-icon v-else slot="icon-only" :icon="pauseOutline"></ion-icon>
-        </ion-button>
         <ion-button @click="onStopClicked" fill="clear">
           <ion-icon slot="icon-only" :icon="stopOutline"></ion-icon>
         </ion-button>
@@ -35,6 +27,14 @@
           <ion-icon slot="icon-only" :icon="playSkipBackOutline"></ion-icon>
         </ion-button>
         <ion-button @click="onSkip(-5)" fill="clear"> -5 </ion-button>
+        <ion-button @click="onPlayPauseClicked" fill="clear" class="bigButton">
+          <ion-icon
+            v-if="playerData.pause"
+            slot="icon-only"
+            :icon="playOutline"
+          ></ion-icon>
+          <ion-icon v-else slot="icon-only" :icon="pauseOutline"></ion-icon>
+        </ion-button>
         <ion-button @click="onSkip(5)" fill="clear"> +5 </ion-button>
         <ion-button @click="onNextClicked" fill="clear">
           <ion-icon slot="icon-only" :icon="playSkipForwardOutline"></ion-icon>
@@ -144,11 +144,37 @@ export default {
 
 <style scoped>
 .videoControls ion-col {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
   margin-right: 1px;
 }
 .videoControls ion-button {
   color: #fff;
   font-size: 10px;
+  flex: 1 1 0;
+  width: auto;
+  --padding-start: 0;
+  --padding-end: 0;
+  --padding-top: 0;
+  --padding-bottom: 0;
+}
+
+.videoControls ion-button.bigButton {
+  flex: 2 1 0;
+  height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  --border-radius: 50%;
+}
+
+.videoControls ion-button.bigButton ion-icon {
+  width: 48px;
+  height: 48px;
+  font-size: 32px;
 }
 
 .videotitle {


### PR DESCRIPTION
- Replaced jcenter() with mavenCentral() since JCenter is deprecated.
- Bumped cordovaAndroidVersion from 7.0.0 to 10.1.1.
- Add more space between the media controls and make the play/pause button bigger.

<img width="491" height="1063" alt="image" src="https://github.com/user-attachments/assets/2d307042-370c-4d7b-9ee8-8c46670bf1ec" />
